### PR TITLE
fix: Create cache dir if doesnt exist

### DIFF
--- a/bin/persistent-evdev.py
+++ b/bin/persistent-evdev.py
@@ -48,6 +48,8 @@ class Device:
 
 
     def make_capabilities_path(self):
+        if not os.path.exists(self.state.cache_path):
+            os.makedirs(self.state.cache_path)
         return os.path.join(self.state.cache_path, self.name + ".json")
 
 


### PR DESCRIPTION
fixes issue #2

i just added to lines
```python
        if not os.path.exists(self.state.cache_path):
            os.makedirs(self.state.cache_path)
```
inside `make_capabilities_path()`